### PR TITLE
Skip non‑file (special buftype) buffers to avoid unnecessary restarts

### DIFF
--- a/lua/roslyn_filewatch/watcher/autocmds.lua
+++ b/lua/roslyn_filewatch/watcher/autocmds.lua
@@ -13,6 +13,12 @@ function M.start(client, root, snapshots, deps)
 	-- BufDelete / BufWipeout
 	local id_main = vim.api.nvim_create_autocmd({ "BufDelete", "BufWipeout" }, {
 		callback = function(args)
+			-- ignore special buftypes
+			local bt = vim.bo[args.buf].buftype
+			if bt ~= "" then
+				return
+			end
+
 			local bufpath = vim.api.nvim_buf_get_name(args.buf)
 			if bufpath ~= "" and normalize_path(bufpath):sub(1, #root) == root then
 				if not uv.fs_stat(bufpath) then
@@ -37,6 +43,12 @@ function M.start(client, root, snapshots, deps)
 	-- BufEnter, BufWritePost, FileChangedRO
 	local id_early = vim.api.nvim_create_autocmd({ "BufEnter", "BufWritePost", "FileChangedRO" }, {
 		callback = function(args)
+			-- ignore special buftypes
+			local bt = vim.bo[args.buf].buftype
+			if bt ~= "" then
+				return
+			end
+
 			local bufpath = vim.api.nvim_buf_get_name(args.buf)
 			if bufpath ~= "" and normalize_path(bufpath):sub(1, #root) == root then
 				if not uv.fs_stat(bufpath) then
@@ -61,6 +73,12 @@ function M.start(client, root, snapshots, deps)
 	-- BufReadPost, BufWritePost
 	local id_extra = vim.api.nvim_create_autocmd({ "BufReadPost", "BufWritePost" }, {
 		callback = function(args)
+			-- ignore special buftypes
+			local bt = vim.bo[args.buf].buftype
+			if bt ~= "" then
+				return
+			end
+
 			local bufpath = vim.api.nvim_buf_get_name(args.buf)
 			if bufpath ~= "" and normalize_path(bufpath):sub(1, #root) == root then
 				if not uv.fs_stat(bufpath) then


### PR DESCRIPTION
In this PR, we ignore special buftypes in autocmds to prevent unnecessary watcher resync/restart operations.